### PR TITLE
Add workflow for format checking of markdown files; fix minor formatting errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/help-request.md
+++ b/.github/ISSUE_TEMPLATE/help-request.md
@@ -54,7 +54,7 @@ Repository Link (if existing):
 - Any other questions or issues we should be aware of?:
 
 
-**P.S.** *Have feedback/comments about our review process? Leave a comment [here][Comments]
+**P.S.** Have feedback/comments about our review process? Leave a comment [here][Comments]
 
 
 [PackagingGuide]: https://www.pyopensci.org/python-package-guide/

--- a/.github/ISSUE_TEMPLATE/help-request.md
+++ b/.github/ISSUE_TEMPLATE/help-request.md
@@ -20,7 +20,7 @@ Repository Link (if existing):
 
 ---
 
--   Paste the full DESCRIPTION file inside a code block below:
+- Paste the full DESCRIPTION file inside a code block below:
 
 ```
 

--- a/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
@@ -46,7 +46,7 @@ scope. (If you are unsure of which category you fit, we suggest you make a pre-s
 	- [ ] Data processing/munging
 	- [ ] Data deposition
 	- [ ] Data validation and testing
-	- [ ] Data visualization **
+	- [ ] Data visualization
 	- [ ] Workflow automation
 	- [ ] Citation management and bibliometrics
 	- [ ] Scientific software wrappers

--- a/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
@@ -35,7 +35,8 @@ existing community please check below:
 
 - Please indicate which [category or categories][PackageCategories] this package falls under:
 
-## Scope 
+## Scope
+
 - Please indicate which category or categories. 
 Check out our [package scope page][PackageCategories] to learn more about our 
 scope. (If you are unsure of which category you fit, we suggest you make a pre-submission inquiry):

--- a/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
@@ -17,7 +17,7 @@ Repository Link (if existing):
 ## Code of Conduct & Commitment to Maintain Package
 
 - [ ] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in maintaining my package after should it be accepted.
-- [ ]I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
+- [ ] I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
 
 ## Description
 

--- a/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
@@ -68,7 +68,7 @@ Domain Specific & Community Partnerships
 - Any other questions or issues we should be aware of:
 
 
-**P.S.** *Have feedback/comments about our review process? Leave a comment [here][Comments]
+**P.S.** Have feedback/comments about our review process? Leave a comment [here][Comments]
 
 
 [PackageCategories]: https://www.pyopensci.org/software-peer-review/about/package-scope.html

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -25,7 +25,7 @@ Date accepted (month/day/year): TBD
 ## Code of Conduct & Commitment to Maintain Package
 
 - [ ] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in maintaining my package after should it be accepted.
-- [ ]I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
+- [ ] I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
 
 ## Description
 

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -117,7 +117,7 @@ Confirm each of the following by checking the box.
 submission and improve our peer review process. We will also ask our reviewers 
 and editors to fill this out.
 
-**P.S.** *Have feedback/comments about our review process? Leave a comment [here][Comments]
+**P.S.** Have feedback/comments about our review process? Leave a comment [here][Comments]
 
 ## Editor and Review Templates
 

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -32,7 +32,8 @@ Date accepted (month/day/year): TBD
 - Include a brief paragraph describing what your package does:
 
 
-## Scope 
+## Scope
+
 - Please indicate which category or categories. 
 Check out our [package scope page][PackageCategories] to learn more about our 
 scope. (If you are unsure of which category you fit, we suggest you make a pre-submission inquiry):
@@ -58,6 +59,7 @@ Domain Specific & Community Partnerships
 ## Community Partnerships
 If your package is associated with an 
 existing community please check below:
+
 - [ ] [Pangeo][pangeoWebsite]
 	- [ ] My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook][PangeoCollaboration]
 
@@ -110,6 +112,7 @@ Confirm each of the following by checking the box.
 - [ ] I expect to maintain this package for at least 2 years and can help find a replacement for the maintainer (team) if needed.
 
 ## Please fill out our survey
+
 - [ ] [Last but not least please fill out our pre-review survey](https://forms.gle/F9mou7S3jhe8DMJ16). This helps us track
 submission and improve our peer review process. We will also ask our reviewers 
 and editors to fill this out.

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -43,7 +43,7 @@ scope. (If you are unsure of which category you fit, we suggest you make a pre-s
 	- [ ] Data processing/munging
 	- [ ] Data deposition
 	- [ ] Data validation and testing
-	- [ ] Data visualization [^1]
+	- [ ] Data visualization[^1]
 	- [ ] Workflow automation
 	- [ ] Citation management and bibliometrics
 	- [ ] Scientific software wrappers
@@ -63,7 +63,7 @@ existing community please check below:
 - [ ] [Pangeo][pangeoWebsite]
 	- [ ] My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook][PangeoCollaboration]
 
-> [^1] Please fill out a pre-submission inquiry before submitting a data visualization package.
+> [^1]: Please fill out a pre-submission inquiry before submitting a data visualization package.
 
 - **For all submissions**, explain how the and why the package falls under the categories you indicated above. In your explanation, please address the following points (briefly, 1-2 sentences for each):  
 

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -43,7 +43,7 @@ scope. (If you are unsure of which category you fit, we suggest you make a pre-s
 	- [ ] Data processing/munging
 	- [ ] Data deposition
 	- [ ] Data validation and testing
-	- [ ] Data visualization **
+	- [ ] Data visualization [^1]
 	- [ ] Workflow automation
 	- [ ] Citation management and bibliometrics
 	- [ ] Scientific software wrappers
@@ -63,7 +63,7 @@ existing community please check below:
 - [ ] [Pangeo][pangeoWebsite]
 	- [ ] My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook][PangeoCollaboration]
 
-> ** Please fill out a pre-submission inquiry before submitting a data visualization package.*
+> [^1] Please fill out a pre-submission inquiry before submitting a data visualization package.
 
 - **For all submissions**, explain how the and why the package falls under the categories you indicated above. In your explanation, please address the following points (briefly, 1-2 sentences for each):  
 

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -11,4 +11,3 @@ jobs:
         with:
           config: .markdownlint.json
           files: '.github'
-          ignore: changelog-entries

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,0 +1,14 @@
+name: Lint docs
+on: [push, pull_request]
+jobs:
+  check_md:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Lint markdown files (markdownlint)
+        uses: articulate/actions-markdownlint@v1
+        with:
+          config: .markdownlint.json
+          files: '.github'
+          ignore: changelog-entries

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -9,5 +9,7 @@
     "MD033": false,
     "MD036": false,
     "MD040": false,
-    "MD047": false
+    "MD047": false,
+    "MD052": false
+    "MD053": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,13 @@
+{
+    "MD007": false,
+    "MD009": false,
+    "MD010": false,
+    "MD012": false,
+    "MD013": false,
+    "MD022": false,
+    "MD024": false,
+    "MD033": false,
+    "MD036": false,
+    "MD040": false,
+    "MD047": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -10,6 +10,6 @@
     "MD036": false,
     "MD040": false,
     "MD047": false,
-    "MD052": false
+    "MD052": false,
     "MD053": false
 }


### PR DESCRIPTION
I found some formatting errors and fixed them. Additionally, I added a markdown linter that we use in https://github.com/precice/tutorials for checking our markdown files. Please note that I deactivated many checks, because I did not want introduce a diff that is too large.