### PR TITLE
Redo software submission form for pyOpenSci

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-software-for-review-DRAFT-PLEASE-DO-NOT-USE.yaml
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review-DRAFT-PLEASE-DO-NOT-USE.yaml
@@ -1,9 +1,6 @@
 name:  Submit Software for Review (Draft)
 description:  Use to submit your Python package for pyOpenSci peer review
-title: 'Feature: '
 labels: ['editor-checks', 'New Submission!']
-assignees: 
-  - placeholder
 body:
   - type: input
     id: "submitting_author"
@@ -41,7 +38,7 @@ body:
     id: "one_line_desc"
     attributes:
       label: One-Line Description of Package
-      description: One-Line Description of Package
+      description: One-line description of package
       placeholder: Description here
     validations:
       required: true
@@ -56,7 +53,7 @@ body:
   - type: input
     id: "version_submitted"
     attributes:
-      label: Version submitted
+      label: Version Submitted
       description: Version submitted
       placeholder: Version here
     validations:
@@ -69,7 +66,11 @@ body:
       options:
         - label: I agree to abide by [pyOpenSci's Code of Conduct](https://www.pyopensci.org/governance/CODE_OF_CONDUCT) during the review process and in maintaining my package after should it be accepted.
           required: true
-        - label: I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines](https://www.pyopensci.org/software-peer-review/our-process/policies.html#after-acceptance-package-ownership-and-maintenance).
+        - label: I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies & Guidelines](https://www.pyopensci.org/software-peer-review/our-process/policies.html#after-acceptance-package-ownership-and-maintenance).
+          required: true
+        - label: I expect to maintain this package for at least 2 years and can help find a replacement for the maintainer (team) if needed.
+          required: true
+        - label: I have read the [author guide](https://www.pyopensci.org/software-peer-review/how-to/author-guide.html). 
           required: true
   - type: textarea
     id: "description"
@@ -83,7 +84,7 @@ body:
     id: "category"
     attributes:
       label: Scope
-      description: "Please select one category or categories. Check out our [package scope page](https://www.pyopensci.org/software-peer-review/about/package-scope.html) to learn more about our scope. (If you are unsure of which category you fit, we suggest you make a pre-submission inquiry):"
+      description: "Please select one or more categories. Check out our [package scope page](https://www.pyopensci.org/software-peer-review/about/package-scope.html) to learn more about our scope. (If you are unsure of which category you fit, we suggest you make a pre-submission inquiry):"
       options:
         - label: Data retrieval
           required: false
@@ -114,17 +115,7 @@ body:
           required: false
         - label: Education
           required: false
-        - label: Pangeo
-          required: false
-  - type: checkboxes
-    id: "community_partnerships"
-    attributes:
-      label: Community partnerships
-      description: "If your package is associated with an existing community please check below:"
-      options:
-        - label: "[Pangeo](https://www.pangeo.io)"
-          required: false
-        - label: My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook](https://www.pyopensci.org/software-peer-review/partners/pangeo)
+        - label: "[Pangeo](https://www.pangeo.io) (My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook](https://www.pyopensci.org/software-peer-review/partners/pangeo))"
           required: false
   - type: textarea
     id: "category_explanation"
@@ -141,7 +132,7 @@ body:
   - type: checkboxes
     id: "technical_checks"
     attributes:
-      label: Technical checks
+      label: Technical Checks
       description: "For details about the pyOpenSci packaging requirements, see our [packaging guide](https://www.pyopensci.org/python-package-guide/). Confirm each of the following by checking the box. This package: "
       options:
         - label: does not violate the Terms of Service of any service it interacts with. 
@@ -156,7 +147,7 @@ body:
           required: false
         - label: has a test suite.
           required: false
-        - label: has continuous integration setup, such as GitHub Actions CircleCI, and/or others.
+        - label: has continuous integration setup, such as GitHub Actions, CircleCI, and/or others.
           required: false
   - type: dropdown
     id: "publication_options"
@@ -166,48 +157,54 @@ body:
       options:
         - I want to automatically submit to JOSS.
         - I don't want to automatically submit to JOSS.
+    validations:
+      required: true
   - type: checkboxes
     id: "publication_options2"
     attributes:
       label: JOSS Checks
       description: "If you want to automatically submit your package to JOSS, please confirm each of the following by checking the box:" 
       options:
-        - label: "The package has an **obvious research application** according to JOSS's definition in their [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements). Be aware that completing the pyOpenSci review process **does not** guarantee acceptance to JOSS. Be sure to read their submission requirements (linked above) if you are interested in submitting to JOSS."
+        - label: "The package has an **obvious research application** according to JOSS's definition in their [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements). Be aware that completing the pyOpenSci review process **does not** guarantee acceptance to JOSS. Be sure to read the submission requirements linked above if you are interested in submitting to JOSS."
           required: false
         - label: |
-                 "The package is not a 'minor utility' as defined by JOSS's [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements): 
-                 'Minor ‘utility’ packages, including ‘thin’ API clients, are not acceptable.' pyOpenSci welcomes these packages under 'Data Retrieval', but JOSS has slightly different criteria."
+                 The package is not a 'minor utility' as defined by JOSS's [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements): 
+                 'Minor ‘utility’ packages, including ‘thin’ API clients, are not acceptable.' pyOpenSci welcomes these packages under 'Data Retrieval', but JOSS has slightly different criteria.
           required: false
         - label: "The package contains a `paper.md` matching [JOSS's requirements](https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain) with a high-level description in the package root or in `inst/`."
           required: false
-        - label: "The package is deposited in a long-term repository with the DOI:"  
+        - label: "The package is deposited in a long-term repository with the DOI listed below."  
           required: false
+  - type: input
+    id: "package_doi"
+    attributes:
+      label: Package DOI
+      description: "Please write the package DOI." 
+      placeholder: DOI here
+    validations:
+      required: false
   - type: checkboxes
     id: "reviewer_options"
     attributes:
       label: Reviewer Options
-      description: "Are you OK with Reviewers Submitting Issues and/or pull requests to your Repo Directly? This option will allow reviewers to open smaller issues that can then be linked to PR's rather than submitting a more dense text based review. It will also allow you to demonstrate addressing the issue via PR links."
+      description: "Are you OK with reviewers submitting issues and/or pull requests to your repo directly? This option will allow reviewers to open smaller issues that can then be linked to PR's rather than submitting a more dense text based review. It will also allow you to demonstrate addressing the issue via PR links."
       options:
-        - label: Yes I am OK with reviewers submitting requested changes as issues to my repo. Reviewers will then link to the issues in their submitted review.
-          required: false
-        - label: I have read the [author guide](https://www.pyopensci.org/software-peer-review/how-to/author-guide.html). 
-          required: false
-        - label: I expect to maintain this package for at least 2 years and can help find a replacement for the maintainer (team) if needed.
+        - label: Yes, I am OK with reviewers submitting requested changes as issues to my repo. Reviewers will then link to the issues in their submitted review.
           required: false
   - type: checkboxes
     id: "survey"
     attributes:
       label: Survey
-      description: "[Last but not least please fill out our pre-review survey](https://forms.gle/F9mou7S3jhe8DMJ16). This helps us track submission and improve our peer review process. We will also ask our reviewers and editors to fill this out."
+      description: "Last but not least please fill out our [pre-review survey](https://forms.gle/F9mou7S3jhe8DMJ16). This helps us track submission and improve our peer review process. We will also ask our reviewers and editors to fill this out."
       options:
-        - label: I have filled in the survey
-          required: false
+        - label: I have filled out the survey.
+          required: true
   - type: checkboxes
     id: "feedback"
     attributes:
       label: Feedback
-      description: "Have feedback/comments about our review process? Leave a comment [here](https://pyopensci.discourse.group/)"
+      description: "Have feedback/comments about our review process? Leave a comment the [pyOpenSci Discourse](https://pyopensci.discourse.group/c/review-process/7)."
       options:
-        - label: I have submitted comments in the survey
+        - label: I have submitted comments in the Discourse.
           required: false
  

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review-DRAFT-PLEASE-DO-NOT-USE.yaml
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review-DRAFT-PLEASE-DO-NOT-USE.yaml
@@ -1,39 +1,213 @@
-name: DRAFT WIP from a SPRINT - PLEASE DO NOT USE THIS TEMPLATE
+name:  Submit Software for Review (Draft)
 description:  Use to submit your Python package for pyOpenSci peer review
 title: 'Feature: '
 labels: ['editor-checks', 'New Submission!']
-assignees:
+assignees: 
   - placeholder
 body:
   - type: input
-    id: "Submitting_Author"
+    id: "submitting_author"
     attributes:
       label: Submitting Author
-      description: Author Name
-      placeholder: github_handle
-    validations:
-      required: true
-  - type: textarea
-    id: "Current_Maintainers"
-    attributes:
-      label: Current Maintainers
-      description: list all current maintainers
-      placeholder: github_handle1, github_handle2
+      description: Author name
+      placeholder: Author name here
     validations:
       required: true
   - type: input
-    id: "Package_Name"
+    id: "maintainer1"
+    attributes:
+      label: Maintainer 1
+      description: GitHub handle for the first mantainer
+      placeholder: GitHub handle here
+    validations:
+      required: true
+  - type: input
+    id: "maintainer2"
+    attributes:
+      label: Maintainer 2
+      description: GitHub handle for the second mantainer
+      placeholder: GitHub handle here
+    validations:
+      required: true
+  - type: input
+    id: "package_name"
     attributes:
       label: Package Name
-      description: Package name here
+      description: Package name
       placeholder: Package name here
     validations:
       required: true
   - type: input
-    id: "One_line_desc"
+    id: "one_line_desc"
     attributes:
       label: One-Line Description of Package
       description: One-Line Description of Package
-      placeholder: description here
+      placeholder: Description here
     validations:
       required: true
+  - type: input
+    id: "repository_link"
+    attributes:
+      label: Repository Link
+      description: Link to the package repository
+      placeholder: Link here
+    validations:
+      required: true
+  - type: input
+    id: "version_submitted"
+    attributes:
+      label: Version submitted
+      description: Version submitted
+      placeholder: Version here
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct & Commitment to Maintain Package
+      description: "Please check the following boxes:"
+      options:
+        - label: I agree to abide by [pyOpenSci's Code of Conduct](https://www.pyopensci.org/governance/CODE_OF_CONDUCT) during the review process and in maintaining my package after should it be accepted.
+          required: true
+        - label: I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines](https://www.pyopensci.org/software-peer-review/our-process/policies.html#after-acceptance-package-ownership-and-maintenance).
+          required: true
+  - type: textarea
+    id: "description"
+    attributes:
+      label: Description
+      description: Include a brief paragraph describing what your package does
+      placeholder: Description here
+    validations:
+      required: true
+  - type: checkboxes
+    id: "category"
+    attributes:
+      label: Scope
+      description: "Please select one category or categories. Check out our [package scope page](https://www.pyopensci.org/software-peer-review/about/package-scope.html) to learn more about our scope. (If you are unsure of which category you fit, we suggest you make a pre-submission inquiry):"
+      options:
+        - label: Data retrieval
+          required: false
+        - label: Data extraction
+          required: false
+        - label: Data processing/munging
+          required: false
+        - label: Data deposition
+          required: false
+        - label: Data validation and testing
+          required: false
+        - label: Data visualization (Please fill out a pre-submission inquiry before submitting a data visualization package.)
+          required: false
+        - label: Workflow automation
+          required: false
+        - label: Citation management and bibliometrics
+          required: false
+        - label: Scientific software wrappers
+          required: false
+        - label: Database interoperability
+  - type: checkboxes
+    id: "partnerships"
+    attributes:
+      label: Domain Specific & Community Partnerships 
+      description: "Please indicate if your package is part of the following domain specific or community partnerships:" 
+      options:
+        - label: Geospatial
+          required: false
+        - label: Education
+          required: false
+        - label: Pangeo
+          required: false
+  - type: checkboxes
+    id: "community_partnerships"
+    attributes:
+      label: Community partnerships
+      description: "If your package is associated with an existing community please check below:"
+      options:
+        - label: "[Pangeo](https://www.pangeo.io)"
+          required: false
+        - label: My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook](https://www.pyopensci.org/software-peer-review/partners/pangeo)
+          required: false
+  - type: textarea
+    id: "category_explanation"
+    attributes:
+      label: Category explanation
+      description: |
+        For all submissions, explain how the and why the package falls under the categories you indicated above. In your explanation, please address the following points (briefly, 1-2 sentences for each)  
+        - Who is the target audience and what are scientific applications of this package?  
+        - Are there other Python packages that accomplish the same thing? If so, how does yours differ?
+        - If you made a pre-submission enquiry, please paste the link to the corresponding issue, forum post, or other discussion, or `@tag` the editor you contacted:
+      placeholder: Explain here
+    validations:
+        required: false
+  - type: checkboxes
+    id: "technical_checks"
+    attributes:
+      label: Technical checks
+      description: "For details about the pyOpenSci packaging requirements, see our [packaging guide](https://www.pyopensci.org/python-package-guide/). Confirm each of the following by checking the box. This package: "
+      options:
+        - label: does not violate the Terms of Service of any service it interacts with. 
+          required: false
+        - label: "uses an [OSI approved license](https://opensource.org/licenses)."
+          required: false
+        - label: contains a README with instructions for installing the development version. 
+          required: false
+        - label: includes documentation with examples for all functions.
+          required: false
+        - label: contains a tutorial with examples of its essential functions and uses.
+          required: false
+        - label: has a test suite.
+          required: false
+        - label: has continuous integration setup, such as GitHub Actions CircleCI, and/or others.
+          required: false
+  - type: dropdown
+    id: "publication_options"
+    attributes:
+      label: Publication Options
+      description: "Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)?"
+      options:
+        - I want to automatically submit to JOSS.
+        - I don't want to automatically submit to JOSS.
+  - type: checkboxes
+    id: "publication_options2"
+    attributes:
+      label: JOSS Checks
+      description: "If you want to automatically submit your package to JOSS, please confirm each of the following by checking the box:" 
+      options:
+        - label: "The package has an **obvious research application** according to JOSS's definition in their [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements). Be aware that completing the pyOpenSci review process **does not** guarantee acceptance to JOSS. Be sure to read their submission requirements (linked above) if you are interested in submitting to JOSS."
+          required: false
+        - label: |
+                 "The package is not a 'minor utility' as defined by JOSS's [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements): 
+                 'Minor ‘utility’ packages, including ‘thin’ API clients, are not acceptable.' pyOpenSci welcomes these packages under 'Data Retrieval', but JOSS has slightly different criteria."
+          required: false
+        - label: "The package contains a `paper.md` matching [JOSS's requirements](https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain) with a high-level description in the package root or in `inst/`."
+          required: false
+        - label: "The package is deposited in a long-term repository with the DOI:"  
+          required: false
+  - type: checkboxes
+    id: "reviewer_options"
+    attributes:
+      label: Reviewer Options
+      description: "Are you OK with Reviewers Submitting Issues and/or pull requests to your Repo Directly? This option will allow reviewers to open smaller issues that can then be linked to PR's rather than submitting a more dense text based review. It will also allow you to demonstrate addressing the issue via PR links."
+      options:
+        - label: Yes I am OK with reviewers submitting requested changes as issues to my repo. Reviewers will then link to the issues in their submitted review.
+          required: false
+        - label: I have read the [author guide](https://www.pyopensci.org/software-peer-review/how-to/author-guide.html). 
+          required: false
+        - label: I expect to maintain this package for at least 2 years and can help find a replacement for the maintainer (team) if needed.
+          required: false
+  - type: checkboxes
+    id: "survey"
+    attributes:
+      label: Survey
+      description: "[Last but not least please fill out our pre-review survey](https://forms.gle/F9mou7S3jhe8DMJ16). This helps us track submission and improve our peer review process. We will also ask our reviewers and editors to fill this out."
+      options:
+        - label: I have filled in the survey
+          required: false
+  - type: checkboxes
+    id: "feedback"
+    attributes:
+      label: Feedback
+      description: "Have feedback/comments about our review process? Leave a comment [here](https://pyopensci.discourse.group/)"
+      options:
+        - label: I have submitted comments in the survey
+          required: false
+ 

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review-DRAFT-PLEASE-DO-NOT-USE.yaml
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review-DRAFT-PLEASE-DO-NOT-USE.yaml
@@ -1,31 +1,103 @@
-name:  Submit Software for Review (Draft)
-description:  Use to submit your Python package for pyOpenSci peer review
+name: Submit Your Package to pyOpenSci for Review
+description: "Use this form to submit your Python package to the pyOpenSci peer review process. If you run into issues, ask on our Discourse forum."
 labels: ['editor-checks', 'New Submission!']
 body:
   - type: input
     id: "submitting_author"
     attributes:
       label: Submitting Author
-      description: Author name
+      description: "Author name (e.g. Janet Doe)"
       placeholder: Author name here
+    validations:
+      required: true
+  - type: input
+    id: "submitting_author_handle"
+    attributes:
+      label: Submitting Author Handle
+      description: Author GitHub handle
+      placeholder: GitHub handle here
     validations:
       required: true
   - type: input
     id: "maintainer1"
     attributes:
       label: Maintainer 1
+      description: First mantainer name
+      placeholder: Maintainer name here
+    validations:
+      required: false
+  - type: input
+    id: "maintainer1_handle"
+    attributes:
+      label: Maintainer 1 Handle
       description: GitHub handle for the first mantainer
       placeholder: GitHub handle here
     validations:
-      required: true
+      required: false
   - type: input
     id: "maintainer2"
     attributes:
       label: Maintainer 2
+      description: Second mantainer name
+      placeholder: Maintainer name here
+    validations:
+      required: false
+  - type: input
+    id: "maintainer2_handle"
+    attributes:
+      label: Maintainer 2 Handle
       description: GitHub handle for the second mantainer
       placeholder: GitHub handle here
     validations:
-      required: true
+      required: false
+  - type: input
+    id: "maintainer3"
+    attributes:
+      label: Maintainer 3
+      description: Third mantainer name
+      placeholder: Maintainer name here
+    validations:
+      required: false
+  - type: input
+    id: "maintainer3_handle"
+    attributes:
+      label: Maintainer 3 Handle
+      description: GitHub handle for the third mantainer
+      placeholder: GitHub handle here
+    validations:
+      required: false
+  - type: input
+    id: "maintainer4"
+    attributes:
+      label: Maintainer 4
+      description: Fourth mantainer name
+      placeholder: Maintainer name here
+    validations:
+      required: false
+  - type: input
+    id: "maintainer4_handle"
+    attributes: 
+      label: Maintainer 4 Handle
+      description: GitHub handle for the fourth mantainer
+      placeholder: GitHub handle here
+    validations:
+      required: false
+  - type: input
+    id: "maintainer5"
+    attributes:
+      label: Maintainer 5
+      description: Fifth mantainer name
+      placeholder: Maintainer name here
+    validations:
+      required: false
+  - type: input
+    id: "maintainer5_handle"
+    attributes:
+      label: Maintainer 5 Handle
+      description: GitHub handle for the fifth mantainer
+      placeholder: GitHub handle here
+    validations:
+      required: false
   - type: input
     id: "package_name"
     attributes:
@@ -38,7 +110,7 @@ body:
     id: "one_line_desc"
     attributes:
       label: One-Line Description of Package
-      description: One-line description of package
+      description: Please try to avoid using overly technical terms if possible for this one line entry.
       placeholder: Description here
     validations:
       required: true
@@ -46,18 +118,26 @@ body:
     id: "repository_link"
     attributes:
       label: Repository Link
-      description: Link to the package repository
-      placeholder: Link here
+      description: Please provide a link to your package's GitHub/GitLab repository.
+      placeholder: Repository link here
     validations:
       required: true
   - type: input
     id: "version_submitted"
     attributes:
       label: Version Submitted
-      description: Version submitted
+      description: Version of the package submitted to pyOpenSci
       placeholder: Version here
     validations:
       required: true
+  - type: input
+    id: "version_link"
+    attributes:
+      label: Link to Version
+      description: Please provide a link to a tag/release or commit for the above version.
+      placeholder: Version link here
+    validations:
+      required: true   
   - type: checkboxes
     id: terms
     attributes:
@@ -68,23 +148,23 @@ body:
           required: true
         - label: I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies & Guidelines](https://www.pyopensci.org/software-peer-review/our-process/policies.html#after-acceptance-package-ownership-and-maintenance).
           required: true
-        - label: I expect to maintain this package for at least 2 years and can help find a replacement for the maintainer (team) if needed.
+        - label: "I expect to maintain this package for at least 2 years.  In case I need to step down as a maintainer, I'm open to support finding a replacement maintainer (team) if needed / if it makes sense for my package."
           required: true
-        - label: I have read the [author guide](https://www.pyopensci.org/software-peer-review/how-to/author-guide.html). 
+        - label: I have read the [pyOS peer review author guide](https://www.pyopensci.org/software-peer-review/how-to/author-guide.html). 
           required: true
   - type: textarea
     id: "description"
     attributes:
       label: Description
-      description: Include a brief paragraph describing what your package does
-      placeholder: Description here
+      description: Please provide a brief and easy-to-understand paragraph describing what your package does. Please try to avoid jargon, or (if used) define jargon to make it clear to our cross-domain editorial team what your package does. 
+      placeholder: Easy-to-understand package description here.
     validations:
       required: true
   - type: checkboxes
     id: "category"
     attributes:
       label: Scope
-      description: "Please select one or more categories. Check out our [package scope page](https://www.pyopensci.org/software-peer-review/about/package-scope.html) to learn more about our scope. (If you are unsure of which category you fit, we suggest you make a pre-submission inquiry):"
+      description: "Please select one or more categories. Check out our [package scope page](https://www.pyopensci.org/software-peer-review/about/package-scope.html) to learn more about our scope. (If you are unsure of which category you fit into, we suggest that you make a pre-submission inquiry):"
       options:
         - label: Data retrieval
           required: false
@@ -96,7 +176,7 @@ body:
           required: false
         - label: Data validation and testing
           required: false
-        - label: Data visualization (Please fill out a pre-submission inquiry before submitting a data visualization package.)
+        - label: Data visualization (please fill out a pre-submission inquiry before submitting a data visualization package)
           required: false
         - label: Workflow automation
           required: false
@@ -106,54 +186,91 @@ body:
           required: false
         - label: Database interoperability
   - type: checkboxes
-    id: "partnerships"
+    id: "categories"
     attributes:
-      label: Domain Specific & Community Partnerships 
-      description: "Please indicate if your package is part of the following domain specific or community partnerships:" 
+      label: Domain Specific Categories
+      description: "Please indicate if your package fits into the categories below (this is optional - it is okay if it doesn't. We use this information to help our package users find packages with functionality that they need):"
       options:
         - label: Geospatial
           required: false
         - label: Education
           required: false
-        - label: "[Pangeo](https://www.pangeo.io) (My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook](https://www.pyopensci.org/software-peer-review/partners/pangeo))"
+  - type: checkboxes
+    id: "partnerships"
+    attributes:
+      label: Community Partnerships 
+      description: |
+        pyOpenSci [partners with communities](https://www.pyopensci.org/software-peer-review/partners/scientific-communities.html#pyopensci-software-peer-review-partnerships) that are maintaining lists of affiliated packages. You do not need to be a part of a community or to fall into a specific domain to apply for peer review. However, if you are a part of the community we will vet your tool against both our pyOpenSci standards and the community specific standards.
+        
+        I would like to be affiliated with a community listed below. (check the box if you believe meet the community affiliation requirements):
+      options:
+        - label: "I wish to be considered to be [Pangeo](https://www.pangeo.io) affiliated. I have [read the pangeo requirements](https://www.pyopensci.org/software-peer-review/partners/pangeo.html#pangeo-specific-software-peer-review-guidelines) and believe my package follows them."
           required: false
   - type: textarea
-    id: "category_explanation"
+    id: "target_audience"
     attributes:
-      label: Category explanation
-      description: |
-        For all submissions, explain how the and why the package falls under the categories you indicated above. In your explanation, please address the following points (briefly, 1-2 sentences for each)  
-        - Who is the target audience and what are scientific applications of this package?  
-        - Are there other Python packages that accomplish the same thing? If so, how does yours differ?
-        - If you made a pre-submission enquiry, please paste the link to the corresponding issue, forum post, or other discussion, or `@tag` the editor you contacted:
+      label: Target Audience
+      description: Please describe the target audience of this package. 
       placeholder: Explain here
+    validations:
+        required: true
+  - type: textarea
+    id: "applications"
+    attributes:
+      label: Scientific Applications
+      description: Please describe the scientific applications of this package.
+      placeholder: Explain here
+    validations:
+        required: true
+  - type: checkboxes
+    id: "other_packages"
+    attributes:
+      label: "Are there any other Python packages that accomplish the same thing?"
+      options:
+        - label: "Yes"
+          required: false
+        - label: "No"
+          required: false
+  - type: textarea
+    id: "other_packages_explanation"
+    attributes:
+      label: "If you answered yes in the previous question, please explain which packages and why."
+      placeholder: Explain here
+    validations:
+        required: false
+  - type: textarea
+    id: "pre-submission"
+    attributes:
+      label: Pre-Submission Link
+      description: If you made a pre-submission, please paste the link here. 
+      placeholder: Link here
     validations:
         required: false
   - type: checkboxes
     id: "technical_checks"
     attributes:
-      label: Technical Checks
+      label: Package Technical Checks
       description: "For details about the pyOpenSci packaging requirements, see our [packaging guide](https://www.pyopensci.org/python-package-guide/). Confirm each of the following by checking the box. This package: "
       options:
         - label: does not violate the Terms of Service of any service it interacts with. 
           required: false
         - label: "uses an [OSI approved license](https://opensource.org/licenses)."
           required: false
-        - label: contains a README with instructions for installing the development version. 
+        - label: contains a README file with instructions for creating an environment for and installing the development version of the package.
           required: false
-        - label: includes documentation with examples for all functions.
+        - label: "includes documentation with examples for all functions and methods (examples in your docstring are optional but encouraged)."
           required: false
-        - label: contains a tutorial with examples of its essential functions and uses.
+        - label: "contains a getting-started tutorial with examples of using the package's essential functions and applications."
           required: false
         - label: has a test suite.
           required: false
-        - label: has continuous integration setup, such as GitHub Actions, CircleCI, and/or others.
+        - label: has continuous integration setup to run tests, such as GitHub Actions, CircleCI, and/or others.
           required: false
   - type: dropdown
     id: "publication_options"
     attributes:
       label: Publication Options
-      description: "Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)?"
+      description: "JOSS has a slightly more refined scope than that of pyOpenSci. If you want to submit your package to JOSS, please use the links below to determine whether your package is in JOSS' scope. Check each box that applies. NOTE: JOSS will make the final determination of whether the package is in scope for their ecosystem. These checks are here to help prepare you for their process and guidelines." 
       options:
         - I want to automatically submit to JOSS.
         - I don't want to automatically submit to JOSS.
@@ -179,7 +296,7 @@ body:
     id: "package_doi"
     attributes:
       label: Package DOI
-      description: "Please write the package DOI." 
+      description: "Please write the package DOI. (At the end of our reviews we ask that you create a final tagged release associated with the review that is linked to a zenodo archive (or some other archive of your choice). An editor will ask you to provide that link when the review is complete. The link will be added here.)" 
       placeholder: DOI here
     validations:
       required: false
@@ -195,16 +312,16 @@ body:
     id: "survey"
     attributes:
       label: Survey
-      description: "Last but not least please fill out our [pre-review survey](https://forms.gle/F9mou7S3jhe8DMJ16). This helps us track submission and improve our peer review process. We will also ask our reviewers and editors to fill this out."
+      description: "Last but not least, please fill out our [pre-review survey](https://forms.gle/F9mou7S3jhe8DMJ16). This helps us track submission and improve our peer review process. We will also ask our reviewers and editors to fill this out."
       options:
         - label: I have filled out the survey.
           required: true
-  - type: checkboxes
+  - type: textarea
     id: "feedback"
     attributes:
       label: Feedback
-      description: "Have feedback/comments about our review process? Leave a comment the [pyOpenSci Discourse](https://pyopensci.discourse.group/c/review-process/7)."
-      options:
-        - label: I have submitted comments in the Discourse.
-          required: false
+      description: "Have feedback/comments about our review process? Leave a comment below or on the [pyOpenSci Discourse](https://pyopensci.discourse.group/c/review-process/7)."
+      placeholder: Comments here
+    validations:
+        required: false
  


### PR DESCRIPTION
This converts the pyOpenSci software submission form from manual template to an actual form using GitHub's issue form syntax.

I applied the suggestions from #113 here except for some things that are not possible with GitHub's syntax. @lwasser.

I also merged the branch in my own fork for testing purposes. You can [click here to see the form](https://github.com/juanis2112/software-submission/issues/new?assignees=&labels=editor-checks%2CNew+Submission%21&projects=&template=submit-software-for-review-DRAFT-PLEASE-DO-NOT-USE.yaml).