### PR TITLE
Add JOSS DOI to review issue metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -16,7 +16,8 @@ Version submitted:
 Editor: TBD  
 Reviewer 1: TBD  
 Reviewer 2: TBD  
-Archive: TBD  
+Archive: TBD
+JOSS DOI: TBD
 Version accepted: TBD 
 Date accepted (month/day/year): TBD
 


### PR DESCRIPTION
For editorial review triage, let's add in JOSS DOI as a metadata field to explicitly track the amazing pyOpenSci packages that are being published 🥳 