### PR TITLE
Add config json to skip 403 url errors

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,3 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: 'config.json'
+    

--- a/config.json
+++ b/config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCodes": [403]
+  "aliveStatusCodes": [403, 200]
 }

--- a/config.json
+++ b/config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCodes": [200, 206]
+  "aliveStatusCodes": [403]
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "aliveStatusCodes": [200, 206]
+}


### PR DESCRIPTION
closes #133 
This should skip 403 errors in our markdown build. let's see 