### PR TITLE
Add archived label to project columns

### DIFF
--- a/update-project.json
+++ b/update-project.json
@@ -5,6 +5,7 @@
 		"1/editor-assigned": "f75ad846",
 		"6/pyOS-approved": "109fa81a",
 		"9/joss-approved": "164e36bb",
-		"presubmission": "47fc9ee4"
+		"presubmission": "47fc9ee4",
+		"archived": "ef283318"
 	}
 }


### PR DESCRIPTION
I added a new column to the [peer review status project](https://github.com/orgs/pyOpenSci/projects/7) for the [archived label](https://github.com/pyOpenSci/software-submission/issues?q=label%3Aarchived). These changes should map that label to the "Archived" column in the project

per https://github.com/pyOpenSci/software-submission/issues/7#issuecomment-2549185186