### PR TITLE
Do not imply that pyOpenSci code of conduct is is infectious

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -26,7 +26,7 @@ Date accepted (month/day/year): TBD
 
 ## Code of Conduct & Commitment to Maintain Package
 
-- [ ] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in future interactions with pyOpenSci should it be accepted.
+- [ ] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in future interactions in spaces supported by pyOpenSci should it be accepted.
 - [ ] I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -26,7 +26,7 @@ Date accepted (month/day/year): TBD
 
 ## Code of Conduct & Commitment to Maintain Package
 
-- [ ] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in maintaining my package after should it be accepted.
+- [ ] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in future interactions with pyOpenSci should it be accepted.
 - [ ] I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
 
 ## Description


### PR DESCRIPTION
When opening a PR to review a package, we ask authors to agree to this statement `I agree to abide by pyOpenSci's Code of Conduct during the review process and in maintaining my package after should it be accepted.`

This seems to intend that every package ever accepted by PyOpenSci has to adopt the PyOpenSci Code of Conduct for the indefinite future for all internal activities (because every activity is related to “maintaining my package” in some way)?
As written, that would apply even if the PyOpenSci’s Code on Conduct changes in the future, i.e. with their submission, projects commit to following rules in decades to come that they don’t even know about yet. That’s a big ask.

I believe that’s not the intent, as in other locations on the website we say `All individuals participating in any pyOpenSci program such as our peer review process, need to abide by our code of conduct.` and  `Our code of conduct is mandatory for everyone involved in our review process.`

In this PR, I adjust our PR template to make clear that the CoC is not infectious in the sense that it applies to interactions with PyOpenSci, but we don't require all projects to adopt the pyOpenSci code of Conduct for everything forever.